### PR TITLE
Align with the breaking changes in ESPHome 2025.11.0

### DIFF
--- a/components/q7rf/q7rf.cpp
+++ b/components/q7rf/q7rf.cpp
@@ -94,13 +94,13 @@ void encode_bits(uint16_t byte, uint8_t pad_to_length, char **dest) {
 
   if (binary_len < pad_to_length) {
     for (int p = 0; p < pad_to_length - binary_len; p++) {
-      strncpy(*dest, Q7RF_ZERO_BIT_DATA, strlen(Q7RF_ZERO_BIT_DATA));
+      memcpy(*dest, Q7RF_ZERO_BIT_DATA, strlen(Q7RF_ZERO_BIT_DATA));
       *dest += strlen(Q7RF_ZERO_BIT_DATA);
     }
   }
 
   for (int b = 0; b < binary_len; b++) {
-    strncpy(*dest, binary[b] == '1' ? Q7RF_ONE_BIT_DATA : Q7RF_ZERO_BIT_DATA, strlen(Q7RF_ONE_BIT_DATA));
+    memcpy(*dest, binary[b] == '1' ? Q7RF_ONE_BIT_DATA : Q7RF_ZERO_BIT_DATA, strlen(Q7RF_ONE_BIT_DATA));
     *dest += strlen(Q7RF_ZERO_BIT_DATA);
   }
 }
@@ -111,7 +111,7 @@ void compile_msg(uint16_t device_id, uint8_t cmd, uint8_t *msg) {
 
   // Preamble
   char *preamble_start = cursor;
-  strncpy(cursor, Q7RF_PREAMBLE_DATA, strlen(Q7RF_PREAMBLE_DATA));
+  memcpy(cursor, Q7RF_PREAMBLE_DATA, strlen(Q7RF_PREAMBLE_DATA));
   cursor += strlen(Q7RF_PREAMBLE_DATA);
 
   char *payload_start = cursor;
@@ -122,15 +122,15 @@ void compile_msg(uint16_t device_id, uint8_t cmd, uint8_t *msg) {
   encode_bits(cmd, 8, &cursor);
 
   // Repeat the command once more
-  strncpy(cursor, payload_start, cursor - payload_start);
+  memcpy(cursor, payload_start, cursor - payload_start);
   cursor += cursor - payload_start;
 
   // Add a gap
-  strncpy(cursor, Q7RF_GAP_DATA, strlen(Q7RF_GAP_DATA));
+  memcpy(cursor, Q7RF_GAP_DATA, strlen(Q7RF_GAP_DATA));
   cursor += strlen(Q7RF_GAP_DATA);
 
   // Repeat the whole burst
-  strncpy(cursor, preamble_start, cursor - preamble_start);
+  memcpy(cursor, preamble_start, cursor - preamble_start);
   cursor += cursor - preamble_start;
 
   // Convert msg to bytes

--- a/components/q7rf/switch.py
+++ b/components/q7rf/switch.py
@@ -11,11 +11,11 @@ CONF_Q7RF_RESEND_INTERVAL = "q7rf_resend_interval"
 CONF_Q7RF_TURN_ON_WATCHDOG_INTERVAL = "q7rf_turn_on_watchdog_interval"
 
 q7rf_ns = cg.esphome_ns.namespace("q7rf")
-Q7RF_SWITCH = q7rf_ns.class_("Q7RFSwitch", switch.Switch, cg.Component, spi.SPIDevice)
+Q7RFSwitch = q7rf_ns.class_("Q7RFSwitch", switch.Switch, cg.PollingComponent, spi.SPIDevice)
 
 CONFIG_SCHEMA = (
-    switch.SWITCH_SCHEMA.extend({cv.GenerateID(): cv.declare_id(Q7RF_SWITCH)})
-    .extend(cv.COMPONENT_SCHEMA)
+    switch.switch_schema(Q7RFSwitch)
+    .extend(cv.polling_component_schema("1s"))
     .extend(spi.spi_device_schema(cs_pin_required=True))
     .extend(
         cv.Schema(


### PR DESCRIPTION
Latest ESPHome introduced breaking changes: [https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/ ](https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/ )With this update, the component works with ESPHome 2025.11.0.

`warning: 'char strncpy(char*, const char*, size_t)' output truncated before terminating nul copying 3 bytes from a string of the same length [-Wstringop-truncation]` is also fixed by using memcpy instead of strncpy.